### PR TITLE
Closes #65 Docs: Define atomic-distance units in the protein-folding API reference

### DIFF
--- a/__demo6/Math.jl
+++ b/__demo6/Math.jl
@@ -1,0 +1,129 @@
+export Math
+"""
+  Math
+
+`Math` algorithms.
+"""
+module Math
+
+using TheAlgorithms
+
+export abs_max
+export abs_min
+export abs_val
+export aliquot_sum
+export amicable_pairs
+export area_circle
+export area_ellipse
+export area_heron_triangle
+export area_parallelogram
+export area_polygon
+export area_rectangle
+export area_regular_polygon
+export area_rhombus
+export area_square
+export area_trapezium
+export area_triangle
+export average_absolute_deviation
+export bab_sqrt
+export bin_length
+export bin_length_long
+export bin_length_short
+export catalan
+export ceil
+export collatz_sequence
+export combination
+export divisors
+export eratosthenes
+export euler_method
+export is_mersenne_prime
+export totient
+export factorial_iterative
+export factorial_recursive
+export fib_recursive
+export fib_recursive_memo
+export fib_iterative
+export floor
+export get_mersenne_primes
+export is_armstrong
+export line_length
+export krishnamurthy
+export mean
+export median
+export mode
+export monte_carlo_integration
+export num_divisors
+export partitions_recursive
+export prime_check
+export prime_factors
+export perfect_cube
+export perfect_number
+export perfect_square
+export permutation
+export prime_check
+export prime_factors
+export riemann_integration
+export runge_kutta_integration
+export simpsons_integration
+export sum_ap
+export sum_gp
+export sum_divisors
+export surfarea_cube
+export surfarea_cuboid
+export surfarea_sphere
+export trapazoidal_area
+export trapezoid_integration
+export verlet_integration
+export vol_cube
+export vol_cuboid
+export vol_cone
+export vol_right_circ_cone
+export vol_prism
+export vol_pyramid
+export vol_sphere
+export vol_circular_cylinder
+export least_common_multiple
+
+include("abs.jl")
+include("amicable_numbers.jl")
+include("area.jl")
+include("armstrong_number.jl")
+include("average_absolute_deviation.jl")
+include("average_mean.jl")
+include("average_median.jl")
+include("average_mode.jl")
+include("babylonian_sqrt.jl")
+include("binary_length.jl")
+include("catalan_number.jl")
+include("ceil.jl") # needed by average_median
+include("collatz_sequence.jl")
+include("combination.jl")
+include("divisors.jl")
+include("euler_method.jl")
+include("eulers_totient.jl")
+include("factorial.jl")
+include("fibonacci.jl")
+include("floor.jl")
+include("krishnamurthy_number.jl")
+include("line_length.jl")
+include("mersenne_prime.jl")
+include("monte_carlo_integration.jl")
+include("partitions.jl")
+include("perfect_cube.jl")
+include("perfect_number.jl")
+include("perfect_square.jl")
+include("permutation.jl")
+include("prime_check.jl")
+include("prime_factors.jl")
+include("riemann_integration.jl")
+include("runge_kutta_integration.jl")
+include("sieve_of_eratosthenes.jl")
+include("simpsons_integration.jl")
+include("sum_of_arithmetic_series.jl")
+include("sum_of_geometric_progression.jl")
+include("trapezoid_integration.jl")
+include("verlet.jl")
+include("volume.jl")
+include("least_common_multiple.jl")
+
+end

--- a/__demo6/NewtonSquareRoot.cs
+++ b/__demo6/NewtonSquareRoot.cs
@@ -1,0 +1,34 @@
+﻿namespace Algorithms;
+
+public static class NewtonSquareRoot
+{
+    public static BigInteger Calculate(BigInteger number)
+    {
+        if (number < 0)
+        {
+            throw new ArgumentException("Cannot calculate the square root of a negative number.");
+        }
+
+        if (number == 0)
+        {
+            return BigInteger.Zero;
+        }
+
+        var bitLength = Convert.ToInt32(Math.Ceiling(BigInteger.Log(number, 2)));
+        BigInteger root = BigInteger.One << (bitLength / 2);
+
+        while (!IsSquareRoot(number, root))
+        {
+            root += number / root;
+            root /= 2;
+        }
+
+        return root;
+    }
+
+    private static bool IsSquareRoot(BigInteger number, BigInteger root)
+    {
+        var lowerBound = root * root;
+        return number >= lowerBound && number <= lowerBound + root + root;
+    }
+}

--- a/__demo6/Problem4.php
+++ b/__demo6/Problem4.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Problem:
+ * A palindromic number reads the same both ways. The largest palindrome made from the product of two 2-digit numbers is 9009 = 91 × 99.
+ * Find the largest palindrome made from the product of two 3-digit numbers.
+ */
+
+/**
+ * @return int
+ */
+function problem4(): int
+{
+    $largest  = 0;
+
+    for ($i = 100; $i < 1000; $i++) {
+        for ($j = $i; $j < 1000; $j++) {
+            $product = $i * $j;
+
+            if (strrev((string)$product) == (string)$product && $product > $largest) {
+                $largest = $product;
+            }
+        }
+    }
+
+    return $largest;
+}

--- a/__demo6/fast_fourier_transform.rs
+++ b/__demo6/fast_fourier_transform.rs
@@ -1,0 +1,224 @@
+use std::ops::{Add, Mul, MulAssign, Sub};
+
+// f64 complex
+#[derive(Clone, Copy, Debug)]
+pub struct Complex64 {
+    pub re: f64,
+    pub im: f64,
+}
+
+impl Complex64 {
+    #[inline]
+    pub fn new(re: f64, im: f64) -> Self {
+        Self { re, im }
+    }
+
+    #[inline]
+    pub fn square_norm(&self) -> f64 {
+        self.re * self.re + self.im * self.im
+    }
+
+    #[inline]
+    pub fn norm(&self) -> f64 {
+        self.square_norm().sqrt()
+    }
+
+    #[inline]
+    pub fn inverse(&self) -> Complex64 {
+        let nrm = self.square_norm();
+        Complex64 {
+            re: self.re / nrm,
+            im: -self.im / nrm,
+        }
+    }
+}
+
+impl Default for Complex64 {
+    #[inline]
+    fn default() -> Self {
+        Self { re: 0.0, im: 0.0 }
+    }
+}
+
+impl Add<Complex64> for Complex64 {
+    type Output = Complex64;
+
+    #[inline]
+    fn add(self, other: Complex64) -> Complex64 {
+        Complex64 {
+            re: self.re + other.re,
+            im: self.im + other.im,
+        }
+    }
+}
+
+impl Sub<Complex64> for Complex64 {
+    type Output = Complex64;
+
+    #[inline]
+    fn sub(self, other: Complex64) -> Complex64 {
+        Complex64 {
+            re: self.re - other.re,
+            im: self.im - other.im,
+        }
+    }
+}
+
+impl Mul<Complex64> for Complex64 {
+    type Output = Complex64;
+
+    #[inline]
+    fn mul(self, other: Complex64) -> Complex64 {
+        Complex64 {
+            re: self.re * other.re - self.im * other.im,
+            im: self.re * other.im + self.im * other.re,
+        }
+    }
+}
+
+impl MulAssign<Complex64> for Complex64 {
+    #[inline]
+    fn mul_assign(&mut self, other: Complex64) {
+        let tmp = self.re * other.im + self.im * other.re;
+        self.re = self.re * other.re - self.im * other.im;
+        self.im = tmp;
+    }
+}
+
+pub fn fast_fourier_transform_input_permutation(length: usize) -> Vec<usize> {
+    let mut result = Vec::new();
+    result.reserve_exact(length);
+    for i in 0..length {
+        result.push(i);
+    }
+    let mut reverse = 0_usize;
+    let mut position = 1_usize;
+    while position < length {
+        let mut bit = length >> 1;
+        while bit & reverse != 0 {
+            reverse ^= bit;
+            bit >>= 1;
+        }
+        reverse ^= bit;
+        // This is equivalent to adding 1 to a reversed number
+        if position < reverse {
+            // Only swap each element once
+            result.swap(position, reverse);
+        }
+        position += 1;
+    }
+    result
+}
+
+pub fn fast_fourier_transform(input: &[f64], input_permutation: &[usize]) -> Vec<Complex64> {
+    let n = input.len();
+    let mut result = Vec::new();
+    result.reserve_exact(n);
+    for position in input_permutation {
+        result.push(Complex64::new(input[*position], 0.0));
+    }
+    let mut segment_length = 1_usize;
+    while segment_length < n {
+        segment_length <<= 1;
+        let angle: f64 = std::f64::consts::TAU / segment_length as f64;
+        let w_len = Complex64::new(angle.cos(), angle.sin());
+        for segment_start in (0..n).step_by(segment_length) {
+            let mut w = Complex64::new(1.0, 0.0);
+            for position in segment_start..(segment_start + segment_length / 2) {
+                let a = result[position];
+                let b = result[position + segment_length / 2] * w;
+                result[position] = a + b;
+                result[position + segment_length / 2] = a - b;
+                w *= w_len;
+            }
+        }
+    }
+    result
+}
+
+pub fn inverse_fast_fourier_transform(
+    input: &[Complex64],
+    input_permutation: &[usize],
+) -> Vec<f64> {
+    let n = input.len();
+    let mut result = Vec::new();
+    result.reserve_exact(n);
+    for position in input_permutation {
+        result.push(input[*position]);
+    }
+    let mut segment_length = 1_usize;
+    while segment_length < n {
+        segment_length <<= 1;
+        let angle: f64 = -std::f64::consts::TAU / segment_length as f64;
+        let w_len = Complex64::new(angle.cos(), angle.sin());
+        for segment_start in (0..n).step_by(segment_length) {
+            let mut w = Complex64::new(1.0, 0.0);
+            for position in segment_start..(segment_start + segment_length / 2) {
+                let a = result[position];
+                let b = result[position + segment_length / 2] * w;
+                result[position] = a + b;
+                result[position + segment_length / 2] = a - b;
+                w *= w_len;
+            }
+        }
+    }
+    let scale = 1.0 / n as f64;
+    result.iter().map(|x| x.re * scale).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn almost_equal(a: f64, b: f64, epsilon: f64) -> bool {
+        (a - b).abs() < epsilon
+    }
+
+    const EPSILON: f64 = 1e-6;
+
+    #[test]
+    fn small_polynomial_returns_self() {
+        let polynomial = vec![1.0f64, 1.0, 0.0, 2.5];
+        let permutation = fast_fourier_transform_input_permutation(polynomial.len());
+        let fft = fast_fourier_transform(&polynomial, &permutation);
+        let ifft = inverse_fast_fourier_transform(&fft, &permutation);
+        for (x, y) in ifft.iter().zip(polynomial.iter()) {
+            assert!(almost_equal(*x, *y, EPSILON));
+        }
+    }
+
+    #[test]
+    fn square_small_polynomial() {
+        let mut polynomial = vec![1.0f64, 1.0, 0.0, 2.0];
+        polynomial.append(&mut vec![0.0; 4]);
+        let permutation = fast_fourier_transform_input_permutation(polynomial.len());
+        let mut fft = fast_fourier_transform(&polynomial, &permutation);
+        for num in fft.iter_mut() {
+            *num *= *num;
+        }
+        let ifft = inverse_fast_fourier_transform(&fft, &permutation);
+        let expected = [1.0, 2.0, 1.0, 4.0, 4.0, 0.0, 4.0, 0.0, 0.0];
+        for (x, y) in ifft.iter().zip(expected.iter()) {
+            assert!(almost_equal(*x, *y, EPSILON));
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn square_big_polynomial() {
+        // This test case takes ~1050ms on my machine in unoptimized mode,
+        // but it takes ~70ms in release mode.
+        let n = 1 << 17; // ~100_000
+        let mut polynomial = vec![1.0f64; n];
+        polynomial.append(&mut vec![0.0f64; n]);
+        let permutation = fast_fourier_transform_input_permutation(polynomial.len());
+        let mut fft = fast_fourier_transform(&polynomial, &permutation);
+        for num in fft.iter_mut() {
+            *num *= *num;
+        }
+        let ifft = inverse_fast_fourier_transform(&fft, &permutation);
+        let expected = (0..((n << 1) - 1)).map(|i| std::cmp::min(i + 1, (n << 1) - 1 - i) as f64);
+        for (&x, y) in ifft.iter().zip(expected) {
+            assert!(almost_equal(x, y, EPSILON));
+        }
+    }
+}

--- a/__demo6/is_square_free.ts
+++ b/__demo6/is_square_free.ts
@@ -1,0 +1,23 @@
+/**
+ * @function isSquareFree
+ * @description A number is said to be square-free if no prime factor divides it more than once, i.e., the largest power of a prime factor that divides n is one.
+ * @param {number} n - A number.
+ * @return {boolean} - True if given number is a square free.
+ * @see https://www.geeksforgeeks.org/square-free-number/
+ * @example isSquareFree(10) = true
+ * @example isSquareFree(20) = false
+ */
+
+export const isSquareFree = (n: number): boolean => {
+  if (n < 0) throw new Error('number must be a natural number > 0')
+  if (n % 2 === 0) n = n / 2
+  if (n % 2 === 0) return false
+
+  for (let i: number = 3; i <= Math.sqrt(n); i = i + 2) {
+    if (n % i === 0) {
+      n = n / i
+      if (n % i === 0) return false
+    }
+  }
+  return true
+}

--- a/__demo6/ternary_Search.dart
+++ b/__demo6/ternary_Search.dart
@@ -1,0 +1,63 @@
+//Title:Ternary Search
+//Author:Shawn
+//Email:stepfencurryxiao@gmail.com
+
+int ternarySearch(var l, var r, var key, var arr) {
+  if (r >= 1) {
+    //Find the mid1 and mid2
+    var mid1 = (l + (r - l) / 3).toInt();
+    var mid2 = (r - (r - 1) / 3).toInt();
+
+    //Check if key is present at any mid
+    if (arr[mid1] == key) return mid1;
+
+    if (arr[mid2] == key) return mid2;
+
+    /*Since Key is not present at mid
+     * check in which region it is present
+     * then repeat the Search operation
+     * in that region
+     */
+
+    if (key < arr[mid1]) {
+      //The Key lies in between 1 and mid1
+      return ternarySearch(l, mid1 - 1, key, arr);
+    } else if (key > arr[mid2]) {
+      //The key lies in between mid2 and r
+      return ternarySearch(mid2 + 1, r, key, arr);
+    } else {
+      //The key lies in between mid1 and mid2
+      return ternarySearch(mid1 + 1, mid2 - 1, key, arr);
+    }
+  }
+
+  //Key not found
+  return -1;
+}
+
+//Driver code
+void main() {
+  var l, r, p, key;
+
+  //Get the array
+  var arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+  //Print the array
+  print(arr);
+
+  //Starting index
+  l = 0;
+
+  // length of array
+  r = arr.length;
+
+  //Checking for 5
+  //Key to be searched in the array
+  key = 5;
+
+  //Search the key using ternarySearch
+  p = ternarySearch(l, r, key, arr);
+
+  //Print the result
+  print("Index of " + key.toString() + " is " + p.toString());
+}


### PR DESCRIPTION
65 This edge case affecting only Python 3.7 will not be addressed since that version reached end-of-life. Our resources are better spent supporting current and future Python versions that the majority of our user base employs.