### PR TITLE
Closes #70 Feature: Modularize FASTQ-to-Parquet conversion for micro-services

### DIFF
--- a/__dev_src8/Dfs.hs
+++ b/__dev_src8/Dfs.hs
@@ -1,0 +1,54 @@
+module Graph.Dfs where
+
+import Data.List
+
+type Node = Int
+type Edge = (Node,Node)
+type Graph = ([Node],[Edge])
+
+depthfirst :: Graph -> Node -> [Node]
+depthfirst (v,e) n
+    | [x|x<-v,x==n] == [] = []
+    | otherwise = dfrecursive (v,e) [n]
+    
+dfrecursive :: Graph -> [Node] -> [Node]
+dfrecursive ([],_) _ = []
+dfrecursive (_,_) [] = []
+dfrecursive (v,e) (top:stack)
+    | [x|x<-v,x==top] == [] = dfrecursive (newv, e) stack
+    | otherwise = top : dfrecursive (newv, e) (adjacent ++ stack)
+    where
+        adjacent = [x | (x,y)<-e,y==top] ++ [x | (y,x)<-e,y==top]
+        newv = [x|x<-v,x/=top]
+        
+connectedcomponents :: Graph -> [[Node]]
+connectedcomponents ([],_) = []
+connectedcomponents (top:v,e) 
+    | remaining == [] = [connected]
+    | otherwise = connected : connectedcomponents (remaining, e)
+    where
+        connected = depthfirst (top:v,e) top
+        remaining = (top:v) \\ connected
+        
+        
+dfsbipartite :: Graph -> [(Node, Int)] -> [Node] -> [Node] -> Bool
+dfsbipartite ([],_) _ _ _ = True
+dfsbipartite (_,_) [] _ _ = True
+dfsbipartite (v,e) ((nv, 0):stack) odd even
+    | [x|x<-v,x==nv] == [] = dfsbipartite (v, e) stack odd even
+    | [] == intersect adjacent even = dfsbipartite (newv, e) ([(x,1)|x<-adjacent] ++ stack) odd (nv : even)
+    | otherwise = False
+    where
+        adjacent = [x | (x,y)<-e,y==nv] ++ [x | (y,x)<-e,y==nv]
+        newv = [x|x<-v,x/=nv]
+dfsbipartite (v,e) ((nv, 1):stack) odd even
+    | [x|x<-v,x==nv] == [] = dfsbipartite (v, e) stack odd even    
+    | [] == intersect adjacent odd = dfsbipartite (newv, e) ([(x,0)|x<-adjacent] ++ stack) (nv : odd) even
+    | otherwise = False
+    where
+        adjacent = [x | (x,y)<-e,y==nv] ++ [x | (y,x)<-e,y==nv]
+        newv = [x|x<-v,x/=nv]
+
+bipartite :: Graph -> Bool
+bipartite ([],_) = True
+bipartite (top:v,e) = dfsbipartite (top:v, e) [(top,0)] [] []

--- a/__dev_src8/NewtonSquareRoot.cs
+++ b/__dev_src8/NewtonSquareRoot.cs
@@ -1,0 +1,34 @@
+﻿namespace Algorithms;
+
+public static class NewtonSquareRoot
+{
+    public static BigInteger Calculate(BigInteger number)
+    {
+        if (number < 0)
+        {
+            throw new ArgumentException("Cannot calculate the square root of a negative number.");
+        }
+
+        if (number == 0)
+        {
+            return BigInteger.Zero;
+        }
+
+        var bitLength = Convert.ToInt32(Math.Ceiling(BigInteger.Log(number, 2)));
+        BigInteger root = BigInteger.One << (bitLength / 2);
+
+        while (!IsSquareRoot(number, root))
+        {
+            root += number / root;
+            root /= 2;
+        }
+
+        return root;
+    }
+
+    private static bool IsSquareRoot(BigInteger number, BigInteger root)
+    {
+        var lowerBound = root * root;
+        return number >= lowerBound && number <= lowerBound + root + root;
+    }
+}

--- a/__dev_src8/ReverseWords.js
+++ b/__dev_src8/ReverseWords.js
@@ -1,0 +1,17 @@
+/**
+ * @function reverseWords
+ * @param {string} str
+ * @returns {string} - reverse string
+ */
+const reverseWords = (str) => {
+  if (typeof str !== 'string') {
+    throw new TypeError('The given value is not a string')
+  }
+
+  return str
+    .split(/\s+/) // create an array with each word in string
+    .reduceRight((reverseStr, word) => `${reverseStr} ${word}`, '') // traverse the array from last & create an string
+    .trim() // remove the first useless space
+}
+
+export default reverseWords

--- a/__dev_src8/problem14.go
+++ b/__dev_src8/problem14.go
@@ -1,0 +1,56 @@
+/**
+* Problem 14 - Longest Collatz sequence
+* @see {@link https://projecteuler.net/problem=14}
+*
+* The following iterative sequence is defined for the set of positive integers:
+* n → n/2 (n is even)
+* n → 3n + 1 (n is odd)
+*
+* Using the rule above and starting with 13, we generate the following sequence:
+* 13 → 40 → 20 → 10 → 5 → 16 → 8 → 4 → 2 → 1
+*
+* Which starting number, under one million, produces the longest chain?
+*
+* NOTE: Once the chain starts the terms are allowed to go above one million.
+*
+* @author ddaniel27
+ */
+package problem14
+
+type dict map[uint64]uint64
+
+var dictionary = dict{
+	1: 1,
+}
+
+func Problem14(limit uint64) uint64 {
+	for i := uint64(2); i <= limit; i++ {
+		weightNextNode(i)
+	}
+
+	var max, maxWeight uint64
+	for k, v := range dictionary {
+		if v > maxWeight {
+			max = k
+			maxWeight = v
+		}
+	}
+
+	return max
+}
+
+func weightNextNode(current uint64) uint64 {
+	var next, weight uint64
+	if current%2 == 0 {
+		next = current / 2
+	} else {
+		next = (3 * current) + 1
+	}
+	if v, ok := dictionary[next]; !ok {
+		weight = weightNextNode(next) + 1
+	} else {
+		weight = v + 1
+	}
+	dictionary[current] = weight
+	return weight
+}

--- a/__dev_src8/transposition_test.go
+++ b/__dev_src8/transposition_test.go
@@ -1,0 +1,133 @@
+// transposition_test.go
+// description: Transposition cipher
+// author(s) [red_byte](https://github.com/i-redbyte)
+// see transposition.go
+
+package transposition
+
+import (
+	"errors"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+const enAlphabet = "abcdefghijklmnopqrstuvwxyz"
+
+var texts = []string{
+	"Ilya Sokolov",
+	"A slice literal is declared just like an array literal, except you leave out the element count",
+	"Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.",
+	"Go’s treatment of errors as values has served us well over the last decade. Although the standard library’s support for errors has been minimal—just the errors.New and fmt.Errorf functions, which produce errors that contain only a message—the built-in error interface allows Go programmers to add whatever information they desire. All it requires is a type that implements an Error method:",
+	"А тут для примера русский текст",
+}
+
+func getRandomString() string {
+	enRunes := []rune(enAlphabet)
+	b := make([]rune, rand.Intn(100))
+	for i := range b {
+		b[i] = enRunes[rand.Intn(len(enRunes))]
+	}
+	return string(b)
+}
+
+func TestEncrypt(t *testing.T) {
+	fn := func(text string, keyWord string) (bool, error) {
+		encrypt, err := Encrypt([]rune(text), keyWord)
+		if err != nil && !errors.Is(err, ErrNoTextToEncrypt) && !errors.Is(err, ErrKeyMissing) {
+			t.Error("Unexpected error ", err)
+		}
+		return text == string(encrypt), err
+	}
+	for _, s := range texts {
+		if check, err := fn(s, getRandomString()); check || err != nil {
+			t.Error("String ", s, " not encrypted")
+		}
+	}
+	if _, err := fn(getRandomString(), ""); err == nil {
+		t.Error("Error! empty string encryption")
+	}
+}
+
+func TestDecrypt(t *testing.T) {
+	for _, s := range texts {
+		keyWord := getRandomString()
+		encrypt, errEncrypt := Encrypt([]rune(s), keyWord)
+		if errEncrypt != nil &&
+			!errors.Is(errEncrypt, ErrNoTextToEncrypt) &&
+			!errors.Is(errEncrypt, ErrKeyMissing) {
+			t.Error("Unexpected error ", errEncrypt)
+		}
+		if errEncrypt != nil {
+			t.Error(errEncrypt)
+		}
+		decrypt, errDecrypt := Decrypt([]rune(encrypt), keyWord)
+		if errDecrypt != nil &&
+			!errors.Is(errDecrypt, ErrNoTextToEncrypt) &&
+			!errors.Is(errDecrypt, ErrKeyMissing) {
+			t.Error("Unexpected error ", errDecrypt)
+		}
+		if errDecrypt != nil {
+			t.Error(errDecrypt)
+		}
+		if reflect.DeepEqual(encrypt, decrypt) {
+			t.Error("String ", s, " not encrypted")
+		}
+		if reflect.DeepEqual(encrypt, s) {
+			t.Error("String ", s, " not encrypted")
+		}
+	}
+}
+
+func TestEncryptDecrypt(t *testing.T) {
+	text := []rune("Test text for checking the algorithm")
+	key1 := "testKey"
+	key2 := "Test Key2"
+	encrypt, errEncrypt := Encrypt(text, key1)
+	if errEncrypt != nil {
+		t.Error(errEncrypt)
+	}
+	decrypt, errDecrypt := Decrypt(encrypt, key1)
+	if errDecrypt != nil {
+		t.Error(errDecrypt)
+	}
+	if !reflect.DeepEqual(decrypt, text) {
+		t.Errorf("The string was not decrypted correctly %q %q", decrypt, text)
+	}
+	decrypt, _ = Decrypt([]rune(encrypt), key2)
+	if reflect.DeepEqual(decrypt, text) {
+		t.Errorf("The string was decrypted with a different key: %q %q", decrypt, text)
+	}
+}
+
+func FuzzTransposition(f *testing.F) {
+	for _, transpositionTestInput := range texts {
+		f.Add(transpositionTestInput)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		keyword := getRandomString()
+		message := []rune(input)
+		encrypted, err := Encrypt(message, keyword)
+		switch {
+		case err == nil:
+		case errors.Is(err, ErrKeyMissing),
+			errors.Is(err, ErrNoTextToEncrypt):
+			return
+		default:
+			t.Fatalf("unexpected error when encrypting string %q: %v", input, err)
+		}
+		decrypted, err := Decrypt([]rune(encrypted), keyword)
+		switch {
+		case err == nil:
+		case errors.Is(err, ErrKeyMissing),
+			errors.Is(err, ErrNoTextToEncrypt):
+			return
+		default:
+			t.Fatalf("unexpected error when decrypting string %q: %v", encrypted, err)
+		}
+
+		if !reflect.DeepEqual(message, decrypted) {
+			t.Fatalf("expected: %+v, got: %+v", message, []rune(decrypted))
+		}
+	})
+}

--- a/__dev_src8/trie.rs
+++ b/__dev_src8/trie.rs
@@ -1,0 +1,155 @@
+//! This module provides a generic implementation of a Trie (prefix tree).
+//! A Trie is a tree-like data structure that is commonly used to store sequences of keys
+//! (such as strings, integers, or other iterable types) where each node represents one element
+//! of the key, and values can be associated with full sequences.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+/// A single node in the Trie structure, representing a key and an optional value.
+#[derive(Debug, Default)]
+struct Node<Key: Default, Type: Default> {
+    /// A map of children nodes where each key maps to another `Node`.
+    children: HashMap<Key, Node<Key, Type>>,
+    /// The value associated with this node, if any.
+    value: Option<Type>,
+}
+
+/// A generic Trie (prefix tree) data structure that allows insertion and lookup
+/// based on a sequence of keys.
+#[derive(Debug, Default)]
+pub struct Trie<Key, Type>
+where
+    Key: Default + Eq + Hash,
+    Type: Default,
+{
+    /// The root node of the Trie, which does not hold a value itself.
+    root: Node<Key, Type>,
+}
+
+impl<Key, Type> Trie<Key, Type>
+where
+    Key: Default + Eq + Hash,
+    Type: Default,
+{
+    /// Creates a new, empty `Trie`.
+    ///
+    /// # Returns
+    /// A `Trie` instance with an empty root node.
+    pub fn new() -> Self {
+        Self {
+            root: Node::default(),
+        }
+    }
+
+    /// Inserts a value into the Trie, associating it with a sequence of keys.
+    ///
+    /// # Arguments
+    /// - `key`: An iterable sequence of keys (e.g., characters in a string or integers in a vector).
+    /// - `value`: The value to associate with the sequence of keys.
+    pub fn insert(&mut self, key: impl IntoIterator<Item = Key>, value: Type)
+    where
+        Key: Eq + Hash,
+    {
+        let mut node = &mut self.root;
+        for c in key {
+            node = node.children.entry(c).or_default();
+        }
+        node.value = Some(value);
+    }
+
+    /// Retrieves a reference to the value associated with a sequence of keys, if it exists.
+    ///
+    /// # Arguments
+    /// - `key`: An iterable sequence of keys (e.g., characters in a string or integers in a vector).
+    ///
+    /// # Returns
+    /// An `Option` containing a reference to the value if the sequence of keys exists in the Trie,
+    /// or `None` if it does not.
+    pub fn get(&self, key: impl IntoIterator<Item = Key>) -> Option<&Type>
+    where
+        Key: Eq + Hash,
+    {
+        let mut node = &self.root;
+        for c in key {
+            node = node.children.get(&c)?;
+        }
+        node.value.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insertion_and_retrieval_with_strings() {
+        let mut trie = Trie::new();
+
+        trie.insert("foo".chars(), 1);
+        assert_eq!(trie.get("foo".chars()), Some(&1));
+        trie.insert("foobar".chars(), 2);
+        assert_eq!(trie.get("foobar".chars()), Some(&2));
+        assert_eq!(trie.get("foo".chars()), Some(&1));
+        trie.insert("bar".chars(), 3);
+        assert_eq!(trie.get("bar".chars()), Some(&3));
+        assert_eq!(trie.get("baz".chars()), None);
+        assert_eq!(trie.get("foobarbaz".chars()), None);
+    }
+
+    #[test]
+    fn test_insertion_and_retrieval_with_integers() {
+        let mut trie = Trie::new();
+
+        trie.insert(vec![1, 2, 3], 1);
+        assert_eq!(trie.get(vec![1, 2, 3]), Some(&1));
+        trie.insert(vec![1, 2, 3, 4, 5], 2);
+        assert_eq!(trie.get(vec![1, 2, 3, 4, 5]), Some(&2));
+        assert_eq!(trie.get(vec![1, 2, 3]), Some(&1));
+        trie.insert(vec![10, 20, 30], 3);
+        assert_eq!(trie.get(vec![10, 20, 30]), Some(&3));
+        assert_eq!(trie.get(vec![4, 5, 6]), None);
+        assert_eq!(trie.get(vec![1, 2, 3, 4, 5, 6]), None);
+    }
+
+    #[test]
+    fn test_empty_trie() {
+        let trie: Trie<char, i32> = Trie::new();
+
+        assert_eq!(trie.get("foo".chars()), None);
+        assert_eq!(trie.get("".chars()), None);
+    }
+
+    #[test]
+    fn test_insert_empty_key() {
+        let mut trie: Trie<char, i32> = Trie::new();
+
+        trie.insert("".chars(), 42);
+        assert_eq!(trie.get("".chars()), Some(&42));
+        assert_eq!(trie.get("foo".chars()), None);
+    }
+
+    #[test]
+    fn test_overlapping_keys() {
+        let mut trie = Trie::new();
+
+        trie.insert("car".chars(), 1);
+        trie.insert("cart".chars(), 2);
+        trie.insert("carter".chars(), 3);
+        assert_eq!(trie.get("car".chars()), Some(&1));
+        assert_eq!(trie.get("cart".chars()), Some(&2));
+        assert_eq!(trie.get("carter".chars()), Some(&3));
+        assert_eq!(trie.get("care".chars()), None);
+    }
+
+    #[test]
+    fn test_partial_match() {
+        let mut trie = Trie::new();
+
+        trie.insert("apple".chars(), 10);
+        assert_eq!(trie.get("app".chars()), None);
+        assert_eq!(trie.get("appl".chars()), None);
+        assert_eq!(trie.get("apple".chars()), Some(&10));
+        assert_eq!(trie.get("applepie".chars()), None);
+    }
+}


### PR DESCRIPTION
70 Closing this as it is a duplicate of the divergent loss issue reported in #402. The stabilization logic was merged in the previous sprint, making this redundant. Discussion regarding RNA-velocity estimation should remain centralized in the original thread to maintain a clean audit trail.