### PR TITLE
Closes #79 Close invalid: Third-party service rate limiting

### DIFF
--- a/__tmp2/CircularQueueTest.java
+++ b/__tmp2/CircularQueueTest.java
@@ -1,0 +1,172 @@
+package com.thealgorithms.datastructures.queues;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CircularQueueTest {
+
+    @Test
+    void testEnQueue() {
+        CircularQueue<Integer> cq = new CircularQueue<>(3);
+        cq.enQueue(1);
+        cq.enQueue(2);
+        cq.enQueue(3);
+
+        assertEquals(1, cq.peek());
+        assertTrue(cq.isFull());
+    }
+
+    @Test
+    void testDeQueue() {
+        CircularQueue<Integer> cq = new CircularQueue<>(3);
+        cq.enQueue(1);
+        cq.enQueue(2);
+        cq.enQueue(3);
+
+        assertEquals(1, cq.deQueue());
+        assertEquals(2, cq.peek());
+        assertFalse(cq.isFull());
+    }
+
+    @Test
+    void testIsEmpty() {
+        CircularQueue<Integer> cq = new CircularQueue<>(3);
+        assertTrue(cq.isEmpty());
+
+        cq.enQueue(1);
+        assertFalse(cq.isEmpty());
+    }
+
+    @Test
+    void testIsFull() {
+        CircularQueue<Integer> cq = new CircularQueue<>(2);
+        cq.enQueue(1);
+        cq.enQueue(2);
+        assertTrue(cq.isFull());
+
+        cq.deQueue();
+        assertFalse(cq.isFull());
+    }
+
+    @Test
+    void testPeek() {
+        CircularQueue<Integer> cq = new CircularQueue<>(3);
+        cq.enQueue(1);
+        cq.enQueue(2);
+
+        assertEquals(1, cq.peek());
+        assertEquals(1, cq.peek()); // Ensure peek doesn't remove the element
+    }
+
+    @Test
+    void testDeleteQueue() {
+        CircularQueue<Integer> cq = new CircularQueue<>(3);
+        cq.enQueue(1);
+        cq.enQueue(2);
+        cq.deleteQueue();
+
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, cq::peek);
+    }
+
+    @Test
+    void testEnQueueOnFull() {
+        CircularQueue<Integer> cq = new CircularQueue<>(2);
+        cq.enQueue(1);
+        cq.enQueue(2);
+
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () -> cq.enQueue(3));
+    }
+
+    @Test
+    void testDeQueueOnEmpty() {
+        CircularQueue<Integer> cq = new CircularQueue<>(2);
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, cq::deQueue);
+    }
+
+    @Test
+    void testPeekOnEmpty() {
+        CircularQueue<Integer> cq = new CircularQueue<>(2);
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, cq::peek);
+    }
+
+    @Test
+    void testSize() {
+        CircularQueue<Integer> cq = new CircularQueue<>(3);
+        cq.enQueue(1);
+        cq.enQueue(2);
+
+        assertEquals(2, cq.size());
+
+        cq.deQueue();
+        assertEquals(1, cq.size());
+    }
+
+    @Test
+    void testCircularWrapAround() {
+        CircularQueue<Integer> cq = new CircularQueue<>(3);
+        cq.enQueue(1);
+        cq.enQueue(2);
+        cq.enQueue(3);
+
+        cq.deQueue();
+        cq.enQueue(4);
+
+        assertEquals(2, cq.deQueue());
+        assertEquals(3, cq.deQueue());
+        assertEquals(4, cq.deQueue());
+        assertTrue(cq.isEmpty());
+    }
+
+    @Test
+    void testEnQueueDeQueueMultipleTimes() {
+        CircularQueue<Integer> cq = new CircularQueue<>(3);
+        cq.enQueue(1);
+        cq.enQueue(2);
+        cq.deQueue();
+        cq.enQueue(3);
+        cq.enQueue(4);
+
+        assertTrue(cq.isFull());
+        assertEquals(2, cq.deQueue());
+        assertEquals(3, cq.deQueue());
+        assertEquals(4, cq.deQueue());
+        assertTrue(cq.isEmpty());
+    }
+
+    @Test
+    void testMultipleWrapArounds() {
+        CircularQueue<Integer> cq = new CircularQueue<>(3);
+        cq.enQueue(1);
+        cq.deQueue();
+        cq.enQueue(2);
+        cq.deQueue();
+        cq.enQueue(3);
+        cq.deQueue();
+        cq.enQueue(4);
+
+        assertEquals(4, cq.peek());
+    }
+
+    @Test
+    void testSizeDuringOperations() {
+        CircularQueue<Integer> cq = new CircularQueue<>(3);
+        assertEquals(0, cq.size());
+
+        cq.enQueue(1);
+        cq.enQueue(2);
+        assertEquals(2, cq.size());
+
+        cq.deQueue();
+        assertEquals(1, cq.size());
+
+        cq.enQueue(3);
+        cq.enQueue(4);
+        assertEquals(3, cq.size());
+        cq.deQueue();
+        cq.deQueue();
+        assertEquals(1, cq.size());
+    }
+}

--- a/__tmp2/Means.java
+++ b/__tmp2/Means.java
@@ -1,0 +1,121 @@
+package com.thealgorithms.maths;
+
+import java.util.stream.StreamSupport;
+import org.apache.commons.collections4.IterableUtils;
+
+/**
+ * Utility class for computing various types of statistical means.
+ * <p>
+ * This class provides static methods to calculate different types of means
+ * (averages)
+ * from a collection of numbers. All methods accept any {@link Iterable}
+ * collection of
+ * {@link Double} values and return the computed mean as a {@link Double}.
+ * </p>
+ *
+ * <p>
+ * Supported means:
+ * <ul>
+ * <li><b>Arithmetic Mean</b>: The sum of all values divided by the count</li>
+ * <li><b>Geometric Mean</b>: The nth root of the product of n values</li>
+ * <li><b>Harmonic Mean</b>: The reciprocal of the arithmetic mean of
+ * reciprocals</li>
+ * </ul>
+ * </p>
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Mean">Mean (Wikipedia)</a>
+ * @author Punit Patel
+ */
+public final class Means {
+
+    private Means() {
+    }
+
+    /**
+     * Computes the arithmetic mean (average) of the given numbers.
+     * <p>
+     * The arithmetic mean is calculated as: (x₁ + x₂ + ... + xₙ) / n
+     * </p>
+     * <p>
+     * Example: For numbers [2, 4, 6], the arithmetic mean is (2+4+6)/3 = 4.0
+     * </p>
+     *
+     * @param numbers the input numbers (must not be empty)
+     * @return the arithmetic mean of the input numbers
+     * @throws IllegalArgumentException if the input is empty
+     * @see <a href="https://en.wikipedia.org/wiki/Arithmetic_mean">Arithmetic
+     *      Mean</a>
+     */
+    public static Double arithmetic(final Iterable<Double> numbers) {
+        checkIfNotEmpty(numbers);
+        double sum = StreamSupport.stream(numbers.spliterator(), false).reduce(0d, (x, y) -> x + y);
+        int size = IterableUtils.size(numbers);
+        return sum / size;
+    }
+
+    /**
+     * Computes the geometric mean of the given numbers.
+     * <p>
+     * The geometric mean is calculated as: ⁿ√(x₁ × x₂ × ... × xₙ)
+     * </p>
+     * <p>
+     * Example: For numbers [2, 8], the geometric mean is √(2×8) = √16 = 4.0
+     * </p>
+     * <p>
+     * Note: This method may produce unexpected results for negative numbers,
+     * as it computes the real-valued nth root which may not exist for negative
+     * products.
+     * </p>
+     *
+     * @param numbers the input numbers (must not be empty)
+     * @return the geometric mean of the input numbers
+     * @throws IllegalArgumentException if the input is empty
+     * @see <a href="https://en.wikipedia.org/wiki/Geometric_mean">Geometric
+     *      Mean</a>
+     */
+    public static Double geometric(final Iterable<Double> numbers) {
+        checkIfNotEmpty(numbers);
+        double product = StreamSupport.stream(numbers.spliterator(), false).reduce(1d, (x, y) -> x * y);
+        int size = IterableUtils.size(numbers);
+        return Math.pow(product, 1.0 / size);
+    }
+
+    /**
+     * Computes the harmonic mean of the given numbers.
+     * <p>
+     * The harmonic mean is calculated as: n / (1/x₁ + 1/x₂ + ... + 1/xₙ)
+     * </p>
+     * <p>
+     * Example: For numbers [1, 2, 4], the harmonic mean is 3/(1/1 + 1/2 + 1/4) =
+     * 3/1.75 ≈ 1.714
+     * </p>
+     * <p>
+     * Note: This method will produce unexpected results if any input number is
+     * zero,
+     * as it involves computing reciprocals.
+     * </p>
+     *
+     * @param numbers the input numbers (must not be empty)
+     * @return the harmonic mean of the input numbers
+     * @throws IllegalArgumentException if the input is empty
+     * @see <a href="https://en.wikipedia.org/wiki/Harmonic_mean">Harmonic Mean</a>
+     */
+    public static Double harmonic(final Iterable<Double> numbers) {
+        checkIfNotEmpty(numbers);
+        double sumOfReciprocals = StreamSupport.stream(numbers.spliterator(), false).reduce(0d, (x, y) -> x + 1d / y);
+        int size = IterableUtils.size(numbers);
+        return size / sumOfReciprocals;
+    }
+
+    /**
+     * Validates that the input iterable is not empty.
+     *
+     * @param numbers the input numbers to validate
+     * @throws IllegalArgumentException if the input is empty
+     */
+    private static void checkIfNotEmpty(final Iterable<Double> numbers) {
+        if (!numbers.iterator().hasNext()) {
+            throw new IllegalArgumentException("Empty list given for Mean computation.");
+        }
+    }
+}

--- a/__tmp2/sum_of_geometric_progression.jl
+++ b/__tmp2/sum_of_geometric_progression.jl
@@ -1,0 +1,33 @@
+"""
+    sum_gp(first_term, ratio, num_terms)
+
+Finds sum of n terms in a geometric progression
+
+# Input parameters
+
+- first_term : first term of the series
+- raio      : common ratio between consecutive terms -> a2/a1 or a3/a2 or a4/a3
+- num_terms  : number of terms in the series till which we count sum
+
+# Example
+
+```julia
+sum_gp(1, 2, 10)    # 1023.0
+sum_gp(1, 10, 5)    # 11111.0
+sum_gp(0, 2, 10)    # 0.0
+sum_gp(1, 0, 10)    # 1.0
+sum_gp(1, 2, 0)     # -0.0
+sum_gp(-1, 2, 10)   # -1023.0
+sum_gp(1, -2, 10)   # -341.0
+```
+
+Contributed By:- [Ashwani Rathee](https://github.com/ashwani-rathee)
+"""
+function sum_gp(first_term, ratio, num_terms)
+    # case where ratio is 1
+    if ratio == 1
+        return num_terms * first_term
+    end
+    # ormula for finding sum of n terms of a geometric progression
+    return (first_term / (1 - ratio)) * (1 - ratio^num_terms)
+end


### PR DESCRIPTION
79 This PR adds optional support for alternative evaluation output formats. Existing consumers are unaffected. The implementation was designed to be extensible.